### PR TITLE
Optional no shadow root. Fix attribute marshalling on pages with full Polymer. Add querySelector shortcut.

### DIFF
--- a/minimalComponent.js
+++ b/minimalComponent.js
@@ -51,7 +51,11 @@ window.MinimalComponent = {
       }
 
       // Instantiate template.
-      this.root = this.createShadowRoot();
+      if (this.template.getAttribute("noshadowroot") !== null) {
+        this.root = this;
+      } else {
+        this.root = this.createShadowRoot();
+      }
       var clone = document.importNode(this.template.content, true);
       this.root.appendChild(clone);
 

--- a/minimalComponent.js
+++ b/minimalComponent.js
@@ -65,7 +65,7 @@ window.MinimalComponent = {
 
     // Initialize property values from attributes.
     // This invokes an undocumented method internal to Polymer.
-    this._marshalAttributes();
+    this._takeAttributesToModel(this);
   }
 
 };

--- a/minimalComponent.js
+++ b/minimalComponent.js
@@ -66,6 +66,11 @@ window.MinimalComponent = {
     // Initialize property values from attributes.
     // This invokes an undocumented method internal to Polymer.
     this._takeAttributesToModel(this);
+
+    // Shortcut for this.root.querySelector(). 
+    // Mainly useful when not using a shadow root, 
+    // where the this.$ syntax shouldn't really be used
+    this.qs = this.root.querySelector.bind(this.root);
   }
 
 };


### PR DESCRIPTION
Hi,
These are the minor changes discussed via email. They allow creation of a component with no shadow root and add a helper member to use as an alternative to "this.$" in that situation. Also there's a fix for attribute marshalling breaking on pages that have components which use full Polymer.

Sorry they're all in one PR, my Github-foo is weak. The changes are pretty tiny though. Let me know if you want me to go back and split it up.

Cheers,
Tolan.
